### PR TITLE
apply json and json5 specs

### DIFF
--- a/languages/json.lang
+++ b/languages/json.lang
@@ -1,14 +1,26 @@
-ws <- space+
-comment <- cap{'/*' (!'*/' .)* '*/'?, "comment"}
-sq_str  <- 'u'? "'" (!['\n] .)* "'"?
-dq_str  <- 'U'? '"' (!["\n] .)* '"'?
+# based on https://www.rfc-editor.org/rfc/rfc7159 and https://spec.json5.org
+
+multi_line_comment <- cap{'//' (![\n\r] .)*, "comment"}
+single_line_comment <- cap{'/*' (!'*/' .)* '*/'?  , "comment"}
+comment <- multi_line_comment / single_line_comment
+
+escape_sequence <- cap{'\\' (!([ux] / digit) . / 'u' xdigit xdigit xdigit xdigit / 'x' xdigit xdigit / digit digit? digit?), "constant.specialChar" }
+single_quote_string <- "'" (![\\'\n\r] . / escape_sequence)* "'"
+double_quote_string <- '"' (![\\"\n\r] . / escape_sequence)* '"'
 string  <- cap{
-    sq_str / dq_str,
+    single_quote_string / double_quote_string,
     "constant.string"
 }
 
-jsonint <- [+\-]? digit+ [Ll]?
-number  <- cap{(float / jsonint), "constant.number"}
+numeric_literal <- ('0' [xX] xdigit+ / "." digit+ / digit+ ("." digit*)? ) ([eE] [+\-]? digit+ )? / cap{
+    words{"Infinity", "NaN"},
+    "keyword"
+}
+
+number <- cap{
+    [+\-]? numeric_literal,
+    "constant.number"
+}
 
 keyword <- cap{
     words{"true", "false", "null"},
@@ -20,8 +32,7 @@ operator <- cap{
     "symbol.operator"
 }
 
-token <- ws
-       / comment
+token <- comment
        / string
        / number
        / keyword

--- a/languages/json.lang
+++ b/languages/json.lang
@@ -1,12 +1,12 @@
 # based on https://www.rfc-editor.org/rfc/rfc7159 and https://spec.json5.org
 
-multi_line_comment <- cap{'//' (![\n\r] .)*, "comment"}
+multi_line_comment <- cap{'//' (![\n] .)*, "comment"}
 single_line_comment <- cap{'/*' (!'*/' .)* '*/'?  , "comment"}
 comment <- multi_line_comment / single_line_comment
 
 escape_sequence <- cap{'\\' (!([ux] / digit) . / 'u' xdigit xdigit xdigit xdigit / 'x' xdigit xdigit / digit digit? digit?), "constant.string.escape" }
-single_quote_string <- "'" (![\\'\n\r] . / escape_sequence)* "'"
-double_quote_string <- '"' (![\\"\n\r] . / escape_sequence)* '"'
+single_quote_string <- "'" (![\\'\n] . / escape_sequence)* "'"
+double_quote_string <- '"' (![\\"\n] . / escape_sequence)* '"'
 string  <- cap{
     single_quote_string / double_quote_string,
     "constant.string"

--- a/languages/json.lang
+++ b/languages/json.lang
@@ -4,7 +4,7 @@ multi_line_comment <- cap{'//' (![\n\r] .)*, "comment"}
 single_line_comment <- cap{'/*' (!'*/' .)* '*/'?  , "comment"}
 comment <- multi_line_comment / single_line_comment
 
-escape_sequence <- cap{'\\' (!([ux] / digit) . / 'u' xdigit xdigit xdigit xdigit / 'x' xdigit xdigit / digit digit? digit?), "constant.specialChar" }
+escape_sequence <- cap{'\\' (!([ux] / digit) . / 'u' xdigit xdigit xdigit xdigit / 'x' xdigit xdigit / digit digit? digit?), "constant.string.escape" }
 single_quote_string <- "'" (![\\'\n\r] . / escape_sequence)* "'"
 double_quote_string <- '"' (![\\"\n\r] . / escape_sequence)* '"'
 string  <- cap{


### PR DESCRIPTION
This changes the `json` language to highlight according to the [json](https://www.rfc-editor.org/rfc/rfc7159) and [json5](https://spec.json5.org/) specs.

It also gets rid of `ws <- space+` which had no effect.
This also removes the `u`/`U` before a string and the `l`/`L` after an integer because I haven't found them in any specs.

Edit:
To make the grammar files more consistent with specific specs it might be good to split standard json and json5 and auto detect which one is used.

Edit2:
Was the `ws <- space+` intended to speed up parsing?