### PR TITLE
fix underline missing in html

### DIFF
--- a/cmd/flare/html.go
+++ b/cmd/flare/html.go
@@ -25,6 +25,9 @@ func (st *HTMLStyler) Style(s, group string) string {
 		if style.Attr&theme.AttrBold != 0 {
 			css += "font-weight:bold;"
 		}
+		if style.Attr&theme.AttrUnderline != 0 {
+			css += "text-decoration:underline;"
+		}
 
 		class := ""
 		if st.class {


### PR DESCRIPTION
This handles underlining text in html.
This fixes #5 .
