### PR TITLE
compile pattern without name

### DIFF
--- a/language.go
+++ b/language.go
@@ -85,7 +85,7 @@ func LoadHighlighter(lang string, data []byte, memo bool) (*Highlighter, error) 
 	var includefn func(lang string) p.Pattern
 	includefn = func(lang string) p.Pattern {
 		data, _ := loadData(lang)
-		token, _ := syntax.Compile(lang+"_", string(data), syntax.CustomFns{
+		token, _ := syntax.Compile(string(data), syntax.CustomFns{
 			Cap:     capfn,
 			Words:   wordsfn,
 			Include: includefn,
@@ -96,7 +96,7 @@ func LoadHighlighter(lang string, data []byte, memo bool) (*Highlighter, error) 
 		return token
 	}
 
-	token, err := syntax.Compile(lang+"_", string(data), syntax.CustomFns{
+	token, err := syntax.Compile(string(data), syntax.CustomFns{
 		Cap:     capfn,
 		Words:   wordsfn,
 		Include: includefn,

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -28,68 +28,68 @@ type CustomFns struct {
 	Imports map[string]pattern.Pattern
 }
 
-func compile(name string, root *memo.Capture, s string, fns CustomFns) pattern.Pattern {
+func compile(root *memo.Capture, s string, fns CustomFns) pattern.Pattern {
 	var p pattern.Pattern
 	switch root.Id() {
 	case idPattern:
-		p = compile(name, root.Child(0), s, fns)
+		p = compile(root.Child(0), s, fns)
 	case idGrammar:
 		nonterms := make(map[string]pattern.Pattern)
 		for k, v := range fns.Imports {
-			nonterms[name+k] = v
+			nonterms[k] = v
 		}
 		it := root.ChildIterator(0)
 		for c := it(); c != nil; c = it() {
-			k, v := compileDef(name, c, s, fns)
-			nonterms[name+k] = v
+			k, v := compileDef( c, s, fns)
+			nonterms[k] = v
 		}
-		p = pattern.Grammar(name+"token", nonterms)
+		p = pattern.Grammar("token", nonterms)
 	case idExpression:
 		alternations := make([]pattern.Pattern, 0, root.NumChildren())
 		it := root.ChildIterator(0)
 		for c := it(); c != nil; c = it() {
-			alternations = append(alternations, compile(name, c, s, fns))
+			alternations = append(alternations, compile(c, s, fns))
 		}
 		p = pattern.Or(alternations...)
 	case idSequence:
 		concats := make([]pattern.Pattern, 0, root.NumChildren())
 		it := root.ChildIterator(0)
 		for c := it(); c != nil; c = it() {
-			concats = append(concats, compile(name, c, s, fns))
+			concats = append(concats, compile(c, s, fns))
 		}
 		p = pattern.Concat(concats...)
 	case idPrefix:
 		c := root.Child(0)
 		switch c.Id() {
 		case idAND:
-			p = pattern.And(compile(name, root.Child(1), s, fns))
+			p = pattern.And(compile(root.Child(1), s, fns))
 		case idNOT:
-			p = pattern.Not(compile(name, root.Child(1), s, fns))
+			p = pattern.Not(compile(root.Child(1), s, fns))
 		default:
-			p = compile(name, root.Child(0), s, fns)
+			p = compile(root.Child(0), s, fns)
 		}
 	case idSuffix:
 		if root.NumChildren() == 2 {
 			c := root.Child(1)
 			switch c.Id() {
 			case idQUESTION:
-				p = pattern.Optional(compile(name, root.Child(0), s, fns))
+				p = pattern.Optional(compile(root.Child(0), s, fns))
 			case idSTAR:
-				p = pattern.Star(compile(name, root.Child(0), s, fns))
+				p = pattern.Star(compile(root.Child(0), s, fns))
 			case idPLUS:
-				p = pattern.Plus(compile(name, root.Child(0), s, fns))
+				p = pattern.Plus(compile(root.Child(0), s, fns))
 			}
 		} else {
-			p = compile(name, root.Child(0), s, fns)
+			p = compile(root.Child(0), s, fns)
 		}
 	case idPrimary:
 		switch root.Child(0).Id() {
 		case idCAP:
-			cpatt := compile(name, root.Child(1), s, fns)
+			cpatt := compile(root.Child(1), s, fns)
 			group := literal(root.Child(2), s)
 			p = fns.Cap(cpatt, group)
 		case idREF:
-			cpatt := compile(name, root.Child(1), s, fns)
+			cpatt := compile(root.Child(1), s, fns)
 			group := literal(root.Child(2), s)
 			p = fns.Ref(cpatt, group)
 		case idBACK:
@@ -109,11 +109,11 @@ func compile(name string, root *memo.Capture, s string, fns CustomFns) pattern.P
 			}
 			p = fns.Words(words...)
 		case idIdentifier, idLiteral, idClass:
-			p = compile(name, root.Child(0), s, fns)
+			p = compile(root.Child(0), s, fns)
 		case idOPEN:
-			p = compile(name, root.Child(1), s, fns)
+			p = compile(root.Child(1), s, fns)
 		case idBRACEPO:
-			p = pattern.Memo(compile(name, root.Child(1), s, fns))
+			p = pattern.Memo(compile(root.Child(1), s, fns))
 		case idDOT:
 			p = pattern.Any(1)
 		}
@@ -142,7 +142,7 @@ func compile(name string, root *memo.Capture, s string, fns CustomFns) pattern.P
 		}
 		p = pattern.Set(set)
 	case idIdentifier:
-		p = pattern.NonTerm(name + parseId(root, s))
+		p = pattern.NonTerm(parseId(root, s))
 	}
 	return p
 }
@@ -193,10 +193,10 @@ func literal(root *memo.Capture, s string) string {
 	return lit.String()
 }
 
-func compileDef(name string, root *memo.Capture, s string, fns CustomFns) (string, pattern.Pattern) {
+func compileDef(root *memo.Capture, s string, fns CustomFns) (string, pattern.Pattern) {
 	id := root.Child(0)
 	exp := root.Child(1)
-	return parseId(id, s), compile(name, exp, s, fns)
+	return parseId(id, s), compile(exp, s, fns)
 }
 
 func compileSet(root *memo.Capture, s string) charset.Set {
@@ -211,7 +211,7 @@ func compileSet(root *memo.Capture, s string) charset.Set {
 	return charset.Set{}
 }
 
-func Compile(name, s string, fns CustomFns) (pattern.Pattern, error) {
+func Compile(s string, fns CustomFns) (pattern.Pattern, error) {
 	match, n, ast, errs := parser.Exec(strings.NewReader(s), memo.NoneTable{})
 	if len(errs) != 0 {
 		return nil, errs[0]
@@ -220,11 +220,11 @@ func Compile(name, s string, fns CustomFns) (pattern.Pattern, error) {
 		return nil, fmt.Errorf("Invalid PEG: failed at %d", n)
 	}
 
-	return compile(name, ast.Child(0), s, fns), nil
+	return compile(ast.Child(0), s, fns), nil
 }
 
-func MustCompile(name, s string, fns CustomFns) pattern.Pattern {
-	p, err := Compile(name, s, fns)
+func MustCompile(s string, fns CustomFns) pattern.Pattern {
+	p, err := Compile(s, fns)
 	if err != nil {
 		panic(err)
 	}

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -40,7 +40,7 @@ func compile(root *memo.Capture, s string, fns CustomFns) pattern.Pattern {
 		}
 		it := root.ChildIterator(0)
 		for c := it(); c != nil; c = it() {
-			k, v := compileDef( c, s, fns)
+			k, v := compileDef(c, s, fns)
 			nonterms[k] = v
 		}
 		p = pattern.Grammar("token", nonterms)


### PR DESCRIPTION
The rules when the grammar is compiled are all prefixed with the name of the grammar.
I think the prefix can be removed without any problems.