### PR TITLE
add hex escape sequence

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -168,6 +168,11 @@ func parseChar(char string) byte {
 			}
 		}
 
+		if char[1] == 'x' {
+			i, _ := strconv.ParseInt(string(char[2:]), 16, 8)
+			return byte(i)
+		}
+
 		i, _ := strconv.ParseInt(string(char[1:]), 8, 8)
 		return byte(i)
 	default:

--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -169,7 +169,7 @@ func parseChar(char string) byte {
 		}
 
 		if char[1] == 'x' {
-			i, _ := strconv.ParseInt(string(char[2:]), 16, 8)
+			i, _ := strconv.ParseUint(string(char[2:]), 16, 8)
 			return byte(i)
 		}
 

--- a/syntax/grammar.go
+++ b/syntax/grammar.go
@@ -250,6 +250,19 @@ var grammar = map[string]p.Pattern{
 			p.Set(charset.New([]byte{'n', 'r', 't', '\'', '"', '[', ']', '\\', '-'})),
 		),
 		p.Concat(
+			p.Literal("\\x"),
+			p.Or(
+				p.Set(charset.Range('0', '9')),
+				p.Set(charset.Range('a', 'f')),
+				p.Set(charset.Range('A', 'F')),
+			),
+			p.Or(
+				p.Set(charset.Range('0', '9')),
+				p.Set(charset.Range('a', 'f')),
+				p.Set(charset.Range('A', 'F')),
+			),
+		),
+		p.Concat(
 			p.Literal("\\"),
 			p.Set(charset.Range('0', '2')),
 			p.Set(charset.Range('0', '7')),

--- a/syntax/grammar.go
+++ b/syntax/grammar.go
@@ -251,15 +251,13 @@ var grammar = map[string]p.Pattern{
 		),
 		p.Concat(
 			p.Literal("\\x"),
-			p.Or(
-				p.Set(charset.Range('0', '9')),
-				p.Set(charset.Range('a', 'f')),
-				p.Set(charset.Range('A', 'F')),
+			p.Set(charset.Range('0', '9').
+				Add(charset.Range('a', 'f')).
+				Add(charset.Range('A', 'F')),
 			),
-			p.Or(
-				p.Set(charset.Range('0', '9')),
-				p.Set(charset.Range('a', 'f')),
-				p.Set(charset.Range('A', 'F')),
+			p.Set(charset.Range('0', '9').
+				Add(charset.Range('a', 'f')).
+				Add(charset.Range('A', 'F')),
 			),
 		),
 		p.Concat(


### PR DESCRIPTION
This allows hex escape sequences in grammars like `\x0A`.
I would also like unicode escape sequences but the pattern is more complicated (see [here](https://en.wikipedia.org/wiki/UTF-8#Encoding)).