### PR TITLE
only allow unsigned escape sequence

### DIFF
--- a/syntax/compile.go
+++ b/syntax/compile.go
@@ -168,7 +168,7 @@ func parseChar(char string) byte {
 			}
 		}
 
-		i, _ := strconv.ParseInt(string(char[1:]), 8, 8)
+		i, _ := strconv.ParseUint(string(char[1:]), 8, 8)
 		return byte(i)
 	default:
 		return char[0]


### PR DESCRIPTION
This change does not really fix a bug.
It just makes more obvious that octal escape sequences (like `\000`) can't have a sign.
`\-000` is not valid.
This change maybe also allows better compiler optimizations.